### PR TITLE
Potential fix for code scanning alert no. 204: Flask app is run in debug mode

### DIFF
--- a/examples/flask/main.py
+++ b/examples/flask/main.py
@@ -102,4 +102,4 @@ def read_root():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=5001)
+    app.run(host="0.0.0.0", port=5001)

--- a/examples/flask/main.py
+++ b/examples/flask/main.py
@@ -102,4 +102,6 @@ def read_root():
 
 
 if __name__ == "__main__":
+    # For local development, you can enable debug mode (including auto-reloading)
+    # by setting the FLASK_DEBUG environment variable to "1" before running the app.
     app.run(host="0.0.0.0", port=5001)


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/vercel/security/code-scanning/204](https://github.com/Dargon789/vercel/security/code-scanning/204)

In general, the problem is fixed by ensuring that Flask is not started with `debug=True` in code that could run in production. Instead, debugging should either be disabled entirely (`debug=False` or omit the parameter) or controlled via configuration or environment variables, and never forced on in the code.

For this specific file, the best minimal fix without changing existing functionality is to stop hardcoding `debug=True` in the `app.run` call on line 105. Flask’s default is `debug=False`, so simply removing the `debug` argument is enough to prevent the debugger from running. If debug behavior is still desired for developers, it can be reintroduced via external configuration (e.g., `FLASK_DEBUG` environment variable) rather than by forcing it in source. We will therefore update `app.run(debug=True, host="0.0.0.0", port=5001)` to `app.run(host="0.0.0.0", port=5001)` in `examples/flask/main.py`. No new imports or additional methods are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Remove explicit debug=True from the Flask app.run call so the example app no longer forces debug mode.